### PR TITLE
Adding an upload stage to the build firmware

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Upload bin
       uses: actions/upload-artifact@v4
       with:
-        name: dynamite-sampler-firmware${{ github.sha }}.bin
-        path: build/dynamite-sampler-firmware.bin
+        name: ${{ env.PROJECT_NAME }}-${{ github.sha }}.bin
+        path: build/${{ env.PROJECT_NAME }}.bin

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Upload bin
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.PROJECT_NAME }}-${{ github.sha }}.bin
-        path: build/${{ env.PROJECT_NAME }}.bin
+        name: dynamite-sampler-firmware-${{ github.sha }}.bin
+        path: build/dynamite-sampler-firmware.bin

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -16,3 +16,9 @@ jobs:
         esp_idf_version: v5.1.4
         target: esp32s3
         path: '.'
+
+    - name: Upload bin
+      uses: actions/upload-artifact@v4
+      with:
+        name: dynamite-sampler-firmware${{ github.sha }}.bin
+        path: build/dynamite-sampler-firmware.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,6 @@ project(dynamite-sampler-firmware)
 
 # Set the env variable for github workflows
 if(DEFINED ENV{GITHUB_ENV})
-  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=${PROJECT_NAME}\n")
+  message(STATUS "Setting GITHUB_ENV for CI workflows")
+  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,11 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Prevents arduino from releasing BLE memory
 add_compile_definitions(ARDUINO_ARCH_ESP32=1)
-project(dynamite-sampler-firmware)
 
 # Set the env variable for github workflows
 if(DEFINED ENV{GITHUB_ENV})
-  message(STATUS "Setting GITHUB_ENV for CI workflows")
+  message(FATAL_ERROR "Setting GITHUB_ENV for CI workflows")
   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
 endif()
+
+project(dynamite-sampler-firmware)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Prevents arduino from releasing BLE memory
 add_compile_definitions(ARDUINO_ARCH_ESP32=1)
-project(esp-arduino-test)
+project(dynamite-sampler-firmware)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,12 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 add_compile_definitions(ARDUINO_ARCH_ESP32=1)
 
 # Set the env variable for github workflows
-if(DEFINED ENV{GITHUB_ENV})
-  message(FATAL_ERROR "Setting GITHUB_ENV for CI workflows")
-  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
-endif()
+file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
+# if(DEFINED ENV{GITHUB_ENV})
+#   message(FATAL_ERROR "Setting GITHUB_ENV for CI workflows")
+#   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
+# endif()
+
 
 project(dynamite-sampler-firmware)
+# message(FATAL_ERROR "after project set")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Prevents arduino from releasing BLE memory
 add_compile_definitions(ARDUINO_ARCH_ESP32=1)
 
+project(dynamite-sampler-firmware)
+
+# TODO this doesn't work
 # Set the env variable for github workflows
-file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
 # if(DEFINED ENV{GITHUB_ENV})
-#   message(FATAL_ERROR "Setting GITHUB_ENV for CI workflows")
 #   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
 # endif()
-
-
-project(dynamite-sampler-firmware)
-# message(FATAL_ERROR "after project set")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,7 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Prevents arduino from releasing BLE memory
 add_compile_definitions(ARDUINO_ARCH_ESP32=1)
 project(dynamite-sampler-firmware)
+
+# Set the env variable for github workflows
+if(DEFINED ENV{GITHUB_ENV})
+  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=${PROJECT_NAME}\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,4 @@ project(dynamite-sampler-firmware)
 # Set the env variable for github workflows
 if(DEFINED ENV{GITHUB_ENV})
   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=${PROJECT_NAME}\n")
+endif()


### PR DESCRIPTION
Upload the .bin file from the build directory. The name is modified to include the git hash.
The name is hardcoded in the `yml` file, to the project name. Ideally the CMake should set the project name as an ENV variable.
Useful so that you can flash other PRs without building yourself.