### PR TITLE
Adding ability to trigger build from github web

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -23,7 +23,7 @@ jobs:
       run: echo "TAG=$(echo $(git describe --always --dirty))" >> $GITHUB_ENV
 
     - name: get env vars
-      run: echo ${{ env.LARRY }} ${{ env.GIT_REVISION }} ${{ env.PROJECT_NAME }}
+      run: echo $LARRY $GIT_REVISION $PROJECT_NAME
 
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -20,7 +20,10 @@ jobs:
 
     # this is the same way the CMake generates the tag.
     - name: Get git description
-      run: echo "TAG=$(echo git describe --always --dirty)" >> $GITHUB_ENV
+      run: echo "TAG=$(echo $(git describe --always --dirty))" >> $GITHUB_ENV
+
+    - name: get env vars
+      run: echo ${{ env.LARRY }} ${{ env.GIT_REVISION }} ${{ env.PROJECT_NAME }}
 
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -23,7 +23,7 @@ jobs:
       run: echo "TAG=$(echo $(git describe --always --dirty))" >> $GITHUB_ENV
 
     - name: get env vars
-      run: echo $LARRY $GIT_REVISION $PROJECT_NAME
+      run: echo "hello:" "$LARRY" "$GIT_REVISION" "$PROJECT_NAME"
 
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -2,11 +2,12 @@ name: Build firmware
 
 on: [pull_request, workflow_dispatch]
 
+env:
+  CONFIGURATION: release 
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CONFIGURATION: release 
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -20,7 +20,7 @@ jobs:
 
     # this is the same way the CMake generates the tag.
     - name: Get git description
-      run: echo "TAG=$(echo git describe --always --dirty))" >> $GITHUB_ENV
+      run: echo "TAG=$(echo git describe --always --dirty)" >> $GITHUB_ENV
 
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -2,9 +2,6 @@ name: Build firmware
 
 on: [pull_request, workflow_dispatch]
 
-env:
-  CONFIGURATION: release 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,15 +16,15 @@ jobs:
         esp_idf_version: v5.1.4
         target: esp32s3
         path: '.'
-        command: idf.py $(python ./generate_idf_flags_from_config_json.py $CONFIGURATION) build
+        command: idf.py $(python ./generate_idf_flags_from_config_json.py release) build
 
-
+    # this is the same way the CMake generates the tag.
     - name: Get git description
       run: echo "TAG=$(echo git describe --always --dirty))" >> $GITHUB_ENV
 
     - name: Upload bin
       uses: actions/upload-artifact@v4
       with:
-        name: dynamite-sampler-firmware-$CONFIGURATION-${{ env.TAG }}.bin
+        name: dynamite-sampler-firmware-release-${{ env.TAG }}.bin
         # This is hardcoded right now, but I'm not sure how to best not hardcode it
-        path: build/$CONFIGURATION/dynamite-sampler-firmware.bin
+        path: build/release/dynamite-sampler-firmware.bin

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,6 +1,6 @@
 name: Build firmware
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -22,9 +22,6 @@ jobs:
     - name: Get git description
       run: echo "TAG=$(echo $(git describe --always --dirty))" >> $GITHUB_ENV
 
-    - name: get env vars
-      run: echo "hello:" "$LARRY" "$GIT_REVISION" "$PROJECT_NAME"
-
     - name: Upload bin
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -5,6 +5,8 @@ on: [pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CONFIGURATION: release 
 
     steps:
     - name: Checkout repo
@@ -16,11 +18,15 @@ jobs:
         esp_idf_version: v5.1.4
         target: esp32s3
         path: '.'
-        command: idf.py $(python ./generate_idf_flags_from_config_json.py release) build
+        command: idf.py $(python ./generate_idf_flags_from_config_json.py $CONFIGURATION) build
+
+
+    - name: Get git description
+      run: echo "TAG=$(echo git describe --always --dirty))" >> $GITHUB_ENV
 
     - name: Upload bin
       uses: actions/upload-artifact@v4
       with:
-        name: dynamite-sampler-firmware-release-${{ github.sha }}.bin
+        name: dynamite-sampler-firmware-$CONFIGURATION-${{ env.TAG }}.bin
         # This is hardcoded right now, but I'm not sure how to best not hardcode it
-        path: build/release/dynamite-sampler-firmware.bin
+        path: build/$CONFIGURATION/dynamite-sampler-firmware.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ set(CMAKE_CXX_STANDARD 20)
 
 # TODO this doesn't work
 # Set the env variable for github workflows
-# if(DEFINED ENV{GITHUB_ENV})
-#   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
-# endif()
+if(DEFINED ENV{GITHUB_ENV})
+  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
+  file(APPEND "$ENV{GITHUB_ENV}" "GIT_REVISION=${GIT_REVISION}\n")
+  file(APPEND "$ENV{GITHUB_ENV}" "LARRY=larry\n")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ set(CMAKE_CXX_STANDARD 20)
 
 # TODO this doesn't work
 # Set the env variable for github workflows
-if(DEFINED ENV{GITHUB_ENV})
-  file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
-  file(APPEND "$ENV{GITHUB_ENV}" "GIT_REVISION=${GIT_REVISION}\n")
-  file(APPEND "$ENV{GITHUB_ENV}" "LARRY=larry\n")
-endif()
+# if(DEFINED ENV{GITHUB_ENV})
+#   file(APPEND "$ENV{GITHUB_ENV}" "PROJECT_NAME=dynamite-sampler-firmware\n")
+# endif()


### PR DESCRIPTION
- Build from web by adding `workflow_dispatch` (untested since the option only shows up on main branch).
- make the git tag be the same as what CMake adds to the firmware