### PR TITLE
Adding kconfig for mock adc option (doesn't implement fully)

### DIFF
--- a/esp_idf_project_configuration.json
+++ b/esp_idf_project_configuration.json
@@ -24,6 +24,32 @@
       "postFlash": ""
     }
   },
+  "debug-mockADC": {
+    "build": {
+      "compileArgs": ["-DIDF_TARGET=esp32s3"],
+      "ninjaArgs": [],
+      "buildDirectoryPath": "${workspaceFolder}/build/debug-mockadc",
+      "sdkconfigDefaults": [
+        "sdkconfig.common",
+        "sdkconfig.debug",
+        "sdkconfig.debug-mockadc"
+      ],
+      "sdkconfigFilePath": "${workspaceFolder}/build/sdkconfig.debug-mockadc"
+    },
+    "flashBaudRate": "",
+    "monitorBaudRate": "",
+    "openOCD": {
+      "debugLevel": 4,
+      "configs": [],
+      "args": []
+    },
+    "tasks": {
+      "preBuild": "",
+      "preFlash": "",
+      "postBuild": "",
+      "postFlash": ""
+    }
+  },
   "release": {
     "build": {
       "compileArgs": [],

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,9 @@
+menu "Dynamite sampler Firmware configuration"
+
+    config MOCK_ADC
+        bool "Use the mock ADC class"
+        default n
+        help
+            Use this on hardware that doesn't have the ADC.
+
+endmenu

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -54,6 +54,14 @@ extern "C" void app_main(void) {
 	Serial.println(GIT_REVISION);
 	Serial.print("Running on Core: ");
 	Serial.println(xPortGetCoreID());
+
+#ifndef CONFIG_MOCK_ADC
+	Serial.println("Mock adc flag not set");
+#else
+	Serial.print("Mock ADC flag: ");
+	Serial.println(CONFIG_MOCK_ADC);
+#endif
+
 	// Serial.print("Config PM SLP IRAM OPT (put lightsleep into ram):");
 	// Serial.println(CONFIG_PM_SLP_IRAM_OPT);
 

--- a/sdkconfig.debug-mockadc
+++ b/sdkconfig.debug-mockadc
@@ -1,0 +1,1 @@
+CONFIG_MOCK_ADC=y


### PR DESCRIPTION
Makes a sdkconfig option to enable a `CONFIG_MOCK_ADC` flag.
Flag is only used to print, isn't actually implemented.