### PR TITLE
Making git describe work with github tags

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -18,9 +18,9 @@ jobs:
         path: '.'
         command: idf.py $(python ./generate_idf_flags_from_config_json.py release) build
 
-    # this is the same way the CMake generates the tag.
+    # this is the same way the main/generate_build_metadata.py generates the version.
     - name: Get git description
-      run: echo "TAG=$(echo $(git describe --always --dirty))" >> $GITHUB_ENV
+      run: echo "TAG=$(echo $(git describe --always --dirty --tags))" >> $GITHUB_ENV
 
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/main/generate_build_metadata.py
+++ b/main/generate_build_metadata.py
@@ -17,7 +17,9 @@ def eprint(*args, **kwargs):
 # --always: if there isn't a tag, use the git hash.
 # --dirty: append -dirty if there are uncommited changes. Since the changes are not
 # commited, the next best thing is to make it apparent that the firmware has been changed.
-r = subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True)
+# --tags: use the non-annotated tags too, since github releases uses that.
+git_cmd = ["git", "describe", "--always", "--dirty", "--tags"]
+r = subprocess.run(git_cmd, capture_output=True)
 git_describe = r.stdout.strip().decode("utf-8")
 
 output = f"""/*


### PR DESCRIPTION
#55 didn't fully fix the issue. Github creates light tags without annotations which `git describe` doesn't use without the `--tags` options.