### PR TITLE
Adding workflow to enforce labels for Semantic Versioning

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+
+  categories:
+    - title: Breaking Changes
+      labels:
+        - SemVer-Major
+    - title: New Features
+      labels:
+        - SemVer-Minor
+    - title: Bugfixes & Refactors
+      labels:
+        - SemVer-Patch
+    - title: Not Firmware changes
+      labels:
+        - SemVer-None
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-      with:
-        # To be able to do git describe
-        fetch-tags: true
 
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+      with:
+        # To be able to do git describe
+        fetch-tags: true
 
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1

--- a/.github/workflows/enforce-semver-labels.yml
+++ b/.github/workflows/enforce-semver-labels.yml
@@ -1,0 +1,14 @@
+name: Enforce SemVer PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        REQUIRED_LABELS_ANY: "SemVer-Major,SemVer-Minor,SemVer-Patch,SemVer-None"
+


### PR DESCRIPTION
A workflow will run to make sure that a `SemVer-` label is attached to each PR.
Added `release.yml` which is used by Github's automatic changelog generator to group PRs by the `SemVer-` label.