### PR TITLE
Fix github workflow: git describe doesn't work because of history

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1


### PR DESCRIPTION
Changing the workflow to pull the history and tags now.