### PR TITLE
Don't run semver label check on editing the PR

### DIFF
--- a/.github/workflows/enforce-semver-labels.yml
+++ b/.github/workflows/enforce-semver-labels.yml
@@ -2,7 +2,7 @@ name: Enforce SemVer PR labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled, opened, synchronize]
 
 jobs:
   enforce-label:


### PR DESCRIPTION
Fixes #65 

The semver label checker github action doesn't need to run when the PR text (title, body, etc) is changed. Previously it ran and caused a slight delay to merge in a PR if you changed the PR text right before merging it in.