### PR TITLE
Move board configuration to `kconfig` menu

### DIFF
--- a/esp_idf_project_configuration.json
+++ b/esp_idf_project_configuration.json
@@ -28,36 +28,6 @@
       "postFlash": ""
     }
   },
-  "debug-mockADC": {
-    "build": {
-      "compileArgs": [
-        "-DIDF_TARGET=esp32s3"
-      ],
-      "ninjaArgs": [],
-      "buildDirectoryPath": "${workspaceFolder}/build/debug-mockadc",
-      "sdkconfigDefaults": [
-        "${workspaceFolder}/sdkconfig.common",
-        "${workspaceFolder}/sdkconfig.debug",
-        "${workspaceFolder}/sdkconfig.debug-mockadc"
-      ],
-      "sdkconfigFilePath": "${workspaceFolder}/build/sdkconfig.debug-mockadc"
-    },
-    "env": {},
-    "idfTarget": "esp32s3",
-    "flashBaudRate": "",
-    "monitorBaudRate": "",
-    "openOCD": {
-      "debugLevel": 2,
-      "configs": [],
-      "args": []
-    },
-    "tasks": {
-      "preBuild": "",
-      "preFlash": "",
-      "postBuild": "",
-      "postFlash": ""
-    }
-  },
   "release": {
     "build": {
       "compileArgs": [

--- a/main/ADS131M0x.cpp
+++ b/main/ADS131M0x.cpp
@@ -404,7 +404,7 @@ void ADS131M0x::setWakeupTask(TaskHandle_t taskToWakeOnDrdy, size_t interval) {
 	isrData.wakeInterval = interval;
 };
 
-#if (USE_MOCK_ADC)
+#ifdef USE_MOCK_ADC
 
 #include <driver/gptimer.h>
 

--- a/main/ADS131M0x.cpp
+++ b/main/ADS131M0x.cpp
@@ -404,7 +404,7 @@ void ADS131M0x::setWakeupTask(TaskHandle_t taskToWakeOnDrdy, size_t interval) {
 	isrData.wakeInterval = interval;
 };
 
-#if (CONFIG_MOCK_ADC == 1)
+#if (USE_MOCK_ADC)
 
 #include <driver/gptimer.h>
 
@@ -474,4 +474,4 @@ const MockAds131::RawOutput *IRAM_ATTR MockAds131::rawReadADC(size_t) const {
 	return &a;
 }
 
-#endif // CONFIG_MOCK_ADC
+#endif // USE_MOCK_ADC

--- a/main/ADS131M0x.cpp
+++ b/main/ADS131M0x.cpp
@@ -404,7 +404,7 @@ void ADS131M0x::setWakeupTask(TaskHandle_t taskToWakeOnDrdy, size_t interval) {
 	isrData.wakeInterval = interval;
 };
 
-#ifdef USE_MOCK_ADC
+#if (CONFIG_MOCK_ADC == 1)
 
 #include <driver/gptimer.h>
 
@@ -474,4 +474,4 @@ const MockAds131::RawOutput *IRAM_ATTR MockAds131::rawReadADC(size_t) const {
 	return &a;
 }
 
-#endif // USE_MOCK_ADC
+#endif // (CONFIG_MOCK_ADC == 1)

--- a/main/ADS131M0x.h
+++ b/main/ADS131M0x.h
@@ -96,7 +96,7 @@ class ADS131M0x {
 	ADS131M0xIsrData isrData;
 };
 
-#ifdef USE_MOCK_ADC
+#if (CONFIG_MOCK_ADC == 1)
 
 #include <driver/gptimer.h>
 
@@ -159,12 +159,12 @@ class MockAds131 {
 	MockAds131xIsrData isrData;
 };
 
-#endif // USE_MOCK_ADC
+#endif // (CONFIG_MOCK_ADC == 1)
 
-#ifdef USE_MOCK_ADC
+#if (CONFIG_MOCK_ADC == 1)
 typedef MockAds131 AdcClass;
 #else
 typedef ADS131M0x AdcClass;
-#endif // USE_MOCK_ADC
+#endif // (CONFIG_MOCK_ADC == 1)
 
 #endif // ADS131M0x_h

--- a/main/ADS131M0x.h
+++ b/main/ADS131M0x.h
@@ -96,7 +96,7 @@ class ADS131M0x {
 	ADS131M0xIsrData isrData;
 };
 
-#if (CONFIG_MOCK_ADC == 1)
+#if (USE_MOCK_ADC)
 
 #include <driver/gptimer.h>
 
@@ -159,12 +159,12 @@ class MockAds131 {
 	MockAds131xIsrData isrData;
 };
 
-#endif // (CONFIG_MOCK_ADC == 1)
+#endif // USE_MOCK_ADC
 
-#if (CONFIG_MOCK_ADC == 1)
+#if (USE_MOCK_ADC)
 typedef MockAds131 AdcClass;
 #else
 typedef ADS131M0x AdcClass;
-#endif // (CONFIG_MOCK_ADC == 1)
+#endif // USE_MOCK_ADC
 
 #endif // ADS131M0x_h

--- a/main/ADS131M0x.h
+++ b/main/ADS131M0x.h
@@ -96,7 +96,7 @@ class ADS131M0x {
 	ADS131M0xIsrData isrData;
 };
 
-#if (USE_MOCK_ADC)
+#ifdef USE_MOCK_ADC
 
 #include <driver/gptimer.h>
 
@@ -161,7 +161,7 @@ class MockAds131 {
 
 #endif // USE_MOCK_ADC
 
-#if (USE_MOCK_ADC)
+#ifdef USE_MOCK_ADC
 typedef MockAds131 AdcClass;
 #else
 typedef ADS131M0x AdcClass;

--- a/main/ADS131M0x_cfg.h
+++ b/main/ADS131M0x_cfg.h
@@ -4,6 +4,8 @@
 #include "ADS131M0x_reg.h"
 
 #if (CONFIG_MOCK_ADC == 1)
+#define USE_MOCK_ADC true
+#else
 #define USE_MOCK_ADC false
 #endif
 

--- a/main/ADS131M0x_cfg.h
+++ b/main/ADS131M0x_cfg.h
@@ -5,10 +5,6 @@
 
 #include "ADS131M0x_reg.h"
 
-#if (CONFIG_MOCK_ADC == 1)
-#define USE_MOCK_ADC 1
-#endif
-
 template <size_t N>
 struct K3BoardCfg {
 	static constexpr size_t NCHAN = N;
@@ -194,15 +190,15 @@ constexpr K3BoardCfg<8> boardv600_Pro{
     .translate = {1, 3, 5, 7, 0, 0, 0, 0},
 };
 
-#if (CONFIG_HW_REV_V3 == 1)
+#if (CONFIG_DYNAMITE_HW_REV_V3 == 1)
 constexpr auto boardConfig{boardv300};
-#elif (CONFIG_HW_REV_V4 == 1)
+#elif (CONFIG_DYNAMITE_HW_REV_V4 == 1)
 constexpr auto boardConfig{boardv400};
-#elif (CONFIG_HW_REV_V5 == 1)
+#elif (CONFIG_DYNAMITE_HW_REV_V5 == 1)
 constexpr auto boardConfig{boardv500};
-#elif (CONFIG_HW_REV_V6_LITE == 1)
+#elif (CONFIG_DYNAMITE_HW_REV_V6_LITE == 1)
 constexpr auto boardConfig{boardv600_lite};
-#elif (CONFIG_HW_REV_V6_PRO == 1)
+#elif (CONFIG_DYNAMITE_HW_REV_V6_PRO == 1)
 constexpr auto boardConfig{boardv600_Pro};
 #else
 #error No board configuration selected.

--- a/main/ADS131M0x_cfg.h
+++ b/main/ADS131M0x_cfg.h
@@ -1,18 +1,19 @@
 #ifndef ADS131M0x_CFG_h
 #define ADS131M0x_CFG_h
 
+#include <stdint.h>
+
 #include "ADS131M0x_reg.h"
 
 #if (CONFIG_MOCK_ADC == 1)
-#define USE_MOCK_ADC true
-#else
-#define USE_MOCK_ADC false
+#define USE_MOCK_ADC 1
 #endif
 
-template <size_t N, bool I2C_PRESENT>
+template <size_t N>
 struct K3BoardCfg {
 	static constexpr size_t NCHAN = N;
-	static constexpr bool HAS_I2C = I2C_PRESENT;
+	char name[8];
+	bool hasI2C;
 
 	bool enable[NCHAN];
 	uint16_t input[NCHAN];
@@ -24,7 +25,9 @@ struct K3BoardCfg {
 };
 
 // V3.0.0 hardware
-constexpr K3BoardCfg<4, false> boardv300{
+constexpr K3BoardCfg<4> boardv300{
+    .name   = "v300",
+    .hasI2C = false,
     .enable =
         {
             false,
@@ -52,7 +55,9 @@ constexpr K3BoardCfg<4, false> boardv300{
 };
 
 // V4.0.0 hardware
-constexpr K3BoardCfg<4, false> boardv400{
+constexpr K3BoardCfg<4> boardv400{
+    .name   = "v400",
+    .hasI2C = false,
     .enable =
         {
             false,
@@ -82,7 +87,9 @@ constexpr K3BoardCfg<4, false> boardv400{
 };
 
 // V5.0.0 hardware
-constexpr K3BoardCfg<4, false> boardv500{
+constexpr K3BoardCfg<4> boardv500{
+    .name   = "v500",
+    .hasI2C = false,
     .enable =
         {
             true,
@@ -112,7 +119,9 @@ constexpr K3BoardCfg<4, false> boardv500{
 };
 
 // V6 Lite hardware
-constexpr K3BoardCfg<4, false> boardv600_lite{
+constexpr K3BoardCfg<4> boardv600_lite{
+    .name   = "v600L",
+    .hasI2C = false,
     .enable =
         {
             true,
@@ -142,7 +151,9 @@ constexpr K3BoardCfg<4, false> boardv600_lite{
 };
 
 // V6 Pro hardware
-constexpr K3BoardCfg<8, true> boardv600_Pro{
+constexpr K3BoardCfg<8> boardv600_Pro{
+    .name   = "v600P",
+    .hasI2C = true,
     .enable =
         {
             true,
@@ -194,8 +205,7 @@ constexpr auto boardConfig{boardv600_lite};
 #elif (CONFIG_HW_REV_V6_PRO == 1)
 constexpr auto boardConfig{boardv600_Pro};
 #else
-// Compiler failure
-blah;
+#error No board configuration selected.
 #endif
 
 #endif // ADS131M0x_CFG_h

--- a/main/ADS131M0x_cfg.h
+++ b/main/ADS131M0x_cfg.h
@@ -3,7 +3,9 @@
 
 #include "ADS131M0x_reg.h"
 
+#if (CONFIG_MOCK_ADC == 1)
 #define USE_MOCK_ADC false
+#endif
 
 template <size_t N, bool I2C_PRESENT>
 struct K3BoardCfg {
@@ -179,6 +181,19 @@ constexpr K3BoardCfg<8, true> boardv600_Pro{
     .translate = {1, 3, 5, 7, 0, 0, 0, 0},
 };
 
+#if (CONFIG_HW_REV_V3 == 1)
 constexpr auto boardConfig{boardv300};
+#elif (CONFIG_HW_REV_V4 == 1)
+constexpr auto boardConfig{boardv400};
+#elif (CONFIG_HW_REV_V5 == 1)
+constexpr auto boardConfig{boardv500};
+#elif (CONFIG_HW_REV_V6_LITE == 1)
+constexpr auto boardConfig{boardv600_lite};
+#elif (CONFIG_HW_REV_V6_PRO == 1)
+constexpr auto boardConfig{boardv600_Pro};
+#else
+// Compiler failure
+blah;
+#endif
 
 #endif // ADS131M0x_CFG_h

--- a/main/ADS131M0x_cfg.h
+++ b/main/ADS131M0x_cfg.h
@@ -3,6 +3,8 @@
 
 #include "ADS131M0x_reg.h"
 
+#define USE_MOCK_ADC false
+
 template <size_t N, bool I2C_PRESENT>
 struct K3BoardCfg {
 	static constexpr size_t NCHAN = N;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,3 +1,24 @@
-menu "Dynamite sampler Firmware configuration"
+menu "Hardware and ADC configuration"
+    choice HARDWARE_REVISION
+        prompt "Select PCB Revision"
+        default HW_REV_V6_PRO
+
+        config HW_REV_V3
+            bool "V3.0.0"
+        config HW_REV_V4
+            bool "V4.0.0"
+        config HW_REV_V5
+            bool "V5.0.0"
+        config HW_REV_V6_LITE
+            bool "V6 Lite"
+        config HW_REV_V6_PRO
+            bool "V6 Pro"
+    endchoice
+
+    config MOCK_ADC
+        bool "Use the mock ADC class"
+        default n
+        help
+            Use this on hardware that doesn't have the ADC, or to mock the ADC.
 
 endmenu

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -20,6 +20,6 @@ menu "Dynamite Sampler hardware configuration"
         bool "Use the mock ADC class"
         default n
         help
-            Use this on hardware that doesn't have the ADC, or to mock the ADC.
+            Use this on hardware that doesn't have the ADC, or to mock the ADC. It will mock the selected hardware.
 
 endmenu

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,17 +1,18 @@
-menu "Hardware and ADC configuration"
-    choice HARDWARE_REVISION
+menu "Dynamite Sampler hardware configuration"
+    choice DYNAMITE_HARDWARE_REVISION
         prompt "Select PCB Revision"
-        default HW_REV_V6_PRO
-
-        config HW_REV_V3
+        default DYNAMITE_HW_REV_V6_PRO
+        help
+            This is the internal version printed on the PCB, not the user "release" version
+        config DYNAMITE_HW_REV_V3
             bool "V3.0.0"
-        config HW_REV_V4
+        config DYNAMITE_HW_REV_V4
             bool "V4.0.0"
-        config HW_REV_V5
+        config DYNAMITE_HW_REV_V5
             bool "V5.0.0"
-        config HW_REV_V6_LITE
+        config DYNAMITE_HW_REV_V6_LITE
             bool "V6 Lite"
-        config HW_REV_V6_PRO
+        config DYNAMITE_HW_REV_V6_PRO
             bool "V6 Pro"
     endchoice
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,9 +1,3 @@
 menu "Dynamite sampler Firmware configuration"
 
-    config MOCK_ADC
-        bool "Use the mock ADC class"
-        default n
-        help
-            Use this on hardware that doesn't have the ADC.
-
 endmenu

--- a/main/ble_proc.cpp
+++ b/main/ble_proc.cpp
@@ -4,7 +4,6 @@
 #include <freertos/stream_buffer.h>
 
 #include <NimBLEDevice.h>
-#include <algorithm>
 
 #include "adc_ble_interface.h"
 #include "adc_proc.h"
@@ -13,6 +12,7 @@
 #include "dynamite_uuid.h"
 #include "loadcell_calibration.h"
 
+#include "ADS131M0x_cfg.h"
 #include "build_metadata.h"
 
 constexpr char TAG[] = "BLE";
@@ -68,10 +68,14 @@ static void setupDeviceInfo(NimBLEServer *server) {
 		ESP_LOGI(TAG, "Set Device manufacturer name to: '%s'", DEVICE_MANUFACTURER_NAME);
 	}
 	{ // Firmware version
+		char s[sizeof(GIT_DESCRIBE) + sizeof(boardConfig.name) + 1];
+		strcpy(s, boardConfig.name);
+		strcat(s, "|");
+		strcat(s, GIT_DESCRIBE);
 		NimBLECharacteristic *chr = srvDeviceInfo->createCharacteristic(
-		    DEVICE_FIRMWARE_VER_CHR_UUID16.value, NIMBLE_PROPERTY::READ, sizeof(GIT_DESCRIBE));
-		chr->setValue(GIT_DESCRIBE);
-		ESP_LOGI(TAG, "Set Device Firmware version to: '%s'", GIT_DESCRIBE);
+		    DEVICE_FIRMWARE_VER_CHR_UUID16.value, NIMBLE_PROPERTY::READ, strlen(s));
+		chr->setValue((uint8_t *)s, strlen(s));
+		ESP_LOGI(TAG, "Set Device Firmware version to: '%s'", s);
 	}
 	{ // Transmitter power
 		NimBLECharacteristic *chr = srvDeviceInfo->createCharacteristic(
@@ -151,7 +155,8 @@ class CalibrationConfigCallbacks : public NimBLECharacteristicCallbacks {
 		size_t idx             = 0;
 		calibrData.data[idx++] = res ? '0' : '1';
 		calibrData.data[idx++] = ' ';
-		const size_t sz        = std::min(len, sizeof(calibrData.data) - idx);
+		const size_t sz =
+		    len < (sizeof(calibrData.data) - idx) ? len : sizeof(calibrData.data) - idx;
 		memcpy(calibrData.data + idx, data, sz);
 		pCharacteristic->notify(calibrData.data, sz + idx);
 	}

--- a/main/i2c_proc.cpp
+++ b/main/i2c_proc.cpp
@@ -139,26 +139,22 @@ void TMP118::readTemperature() {
 static void taskSetupI2C(void *setupDone) {
 	ESP_LOGI(TAG, "setting up I2C on core: %u", esp_cpu_get_core_id());
 	I2CMasterBus bus;
-	if (!bus.setup()) {
-		vTaskDelete(NULL);
-	}
 	TMP118 sensor;
-	if (!sensor.config(bus)) {
+	if (bus.setup() && sensor.config(bus)) {
+		*(volatile bool *)setupDone = true;
+	} else {
 		vTaskDelete(NULL);
 	}
-
-	*(volatile bool *)setupDone = true;
 
 	while (true) {
 		delayMSec(1000);
 		sensor.readTemperature();
 	}
-
 	vTaskDelete(NULL);
 }
 
 void setupI2C(int core) {
-	if constexpr (boardConfig.HAS_I2C) {
+	if constexpr (boardConfig.hasI2C) {
 		volatile bool done = false;
 		xTaskCreatePinnedToCore(taskSetupI2C, "task_I2C_setup", 1024 * 2, (void *)&done, 1, NULL,
 		                        core);

--- a/main/i2c_proc.cpp
+++ b/main/i2c_proc.cpp
@@ -143,6 +143,7 @@ static void taskSetupI2C(void *setupDone) {
 	if (bus.setup() && sensor.config(bus)) {
 		*(volatile bool *)setupDone = true;
 	} else {
+		// TODO: improve error handlng
 		vTaskDelete(NULL);
 	}
 

--- a/sdkconfig.debug-mockadc
+++ b/sdkconfig.debug-mockadc
@@ -1,1 +1,0 @@
-CONFIG_MOCK_ADC=y


### PR DESCRIPTION
Set the board revision in the `kconfig` instead of `ADS131M0x_cfg.h` file.
Remove the `debug-mockadc` build option. Now it is just a `kconfig` option.

Having `debug-mockadc` wasn't a good UX, and didn't make sense.
Having board revisions set in the `kconfig` allows the user to set it locally without changing the hardcoded values.
